### PR TITLE
twiddle runs-per-fork knob

### DIFF
--- a/aflPersistent.ml
+++ b/aflPersistent.ml
@@ -9,7 +9,7 @@ let run f =
   let pid = Unix.getpid () in
   if persist then begin
     reset_instrumentation true;
-    for i = 1 to 1000 do
+    for i = 1 to 500 do
       f ();
       Unix.kill pid Sys.sigstop;
       reset_instrumentation false


### PR DESCRIPTION
I got consistent spurious crashes sometimes when running Crowbar tests with this value set to 1000.  The right answer is probably something smarter than a static value, but I don't know what it should be or how to get there, and this change might help others seeing the same problem.