### PR TITLE
Support new location of unix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ cd `dirname $0`
 rm -rf _build/; rm -f afl-persistent.config
 mkdir _build; cd _build
 
-ocamlc='ocamlc -g -bin-annot'
-ocamlopt='ocamlopt -g -bin-annot'
+ocamlc='ocamlc -g -bin-annot -I +unix'
+ocamlopt='ocamlopt -g -bin-annot -I +unix'
 
 echo 'print_string "hello"' > afl_check.ml
 
@@ -52,5 +52,5 @@ $ocamlopt -a aflPersistent.cmx -o afl-persistent.cmxa
 
 # test
 cp ../test.ml .
-ocamlc unix.cma afl-persistent.cma test.ml -o test && ./test
-ocamlopt unix.cmxa afl-persistent.cmxa test.ml -o test && ./test
+ocamlc -I +unix unix.cma afl-persistent.cma test.ml -o test && ./test
+ocamlopt -I +unix unix.cmxa afl-persistent.cmxa test.ml -o test && ./test


### PR DESCRIPTION
Provides compatibility to silence the alert proposed in ocaml/ocaml#11198. The change is compatible with previous OCaml releases, but it's obviously not worth merging this unless/until the OCaml PR is accepted.